### PR TITLE
.targets file update & Terminal crash fix

### DIFF
--- a/Disa.Terminal/Program.cs
+++ b/Disa.Terminal/Program.cs
@@ -106,6 +106,13 @@ namespace Disa.Terminal
 
         private static async void DoCommand(string command)
         {
+			// Clean the input
+			command = command.Trim();
+			// Don't do anything if we have empty input
+			if(command == "")
+				return;
+
+			// Split and handle command
             var args = SplitCommandLine(command).ToList();
 
             switch (args[0].ToLower())

--- a/packages/SQLitePCL.raw_basic.0.8.0/build/net45/SQLitePCL.raw_basic.targets
+++ b/packages/SQLitePCL.raw_basic.0.8.0/build/net45/SQLitePCL.raw_basic.targets
@@ -1,13 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Automatically generated-->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="check_cpu_fdfd2d5e-f2f5-42a4-9f6e-19d1f9d64c48" BeforeTargets="ResolveAssemblyReferences" Condition=" ( ($(Platform.ToLower()) != 'x86') AND ($(Platform.ToLower()) != 'x64') AND ($(OS) == 'Windows_NT') ) ">
+    <Warning Text="$(Platform) is not supported. The Platform configuration must be x86 or x64" />
+  </Target>
   <Target Name="InjectReference_36dfbe83-9b2b-4cde-bbdb-00b49ceedbec" BeforeTargets="ResolveAssemblyReferences">
-    <ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">
+    <ItemGroup Condition=" '$(Platform.ToLower())' == 'x86' ">
       <Content Include="$(MSBuildThisFileDirectory)..\..\build\native\sqlite3_dynamic\winxp\x86\sqlite3.dll">
         <Link>x86\sqlite3.dll</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
-      <Content Include="$(MSBuildThisFileDirectory)..\..\build\native\sqlite3_dynamic\winxp\x64\sqlite3.dll">
+	</ItemGroup>
+	<ItemGroup Condition=" '$(Platform.ToLower())' == 'x64' ">
+	  <Content Include="$(MSBuildThisFileDirectory)..\..\build\native\sqlite3_dynamic\winxp\x64\sqlite3.dll">
         <Link>x64\sqlite3.dll</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>

--- a/packages/SQLitePCL.raw_basic.0.8.0/build/net45/SQLitePCL.raw_basic.targets
+++ b/packages/SQLitePCL.raw_basic.0.8.0/build/net45/SQLitePCL.raw_basic.targets
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Automatically generated-->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="check_cpu_fdfd2d5e-f2f5-42a4-9f6e-19d1f9d64c48" BeforeTargets="ResolveAssemblyReferences" Condition=" ( ($(Platform.ToLower()) != 'x86') AND ($(Platform.ToLower()) != 'x64') AND ($(OS) == 'Windows_NT') ) ">
-    <Warning Text="$(Platform) is not supported. The Platform configuration must be x86 or x64" />
+  <Target Name="check_cpu_fdfd2d5e-f2f5-42a4-9f6e-19d1f9d64c48" BeforeTargets="ResolveAssemblyReferences" Condition=" ( ($(Platform.ToLower()) != 'x86') AND ($(Platform.ToLower()) != 'x64') OR ($(OS) != 'Windows_NT') ) ">
+    <Warning Text="$(Platform) is not supported. The Platform configuration must be Windows x86 or x64" />
   </Target>
   <Target Name="InjectReference_36dfbe83-9b2b-4cde-bbdb-00b49ceedbec" BeforeTargets="ResolveAssemblyReferences">
     <ItemGroup Condition=" '$(Platform.ToLower())' == 'x86' ">


### PR DESCRIPTION
Update SQLitePCL.raw net45 .targets file, now properly checks for platform and links the correct dll Fix crash on invalid command strings (Empty string or spaces)
